### PR TITLE
Fix exception when index.rss is accessed

### DIFF
--- a/upload/library/Sedo/AdvBBcodeBar/BbCode/Formatter/AdvBbCodes.php
+++ b/upload/library/Sedo/AdvBBcodeBar/BbCode/Formatter/AdvBbCodes.php
@@ -435,10 +435,6 @@ class Sedo_AdvBBcodeBar_BbCode_Formatter_AdvBbCodes
 				$sourceText = true;
 				$url = $source_data;
 			}
-			elseif($option == 'no-mobile')
-			{
-				 $useResponsiveMode = false;
-			}
 			elseif(preg_match('#[\s]*({URL=.+?})[\s]*#ui', $source_data))
 			{
 				$sourceText = true;


### PR DESCRIPTION
When grabbing posts via RSS, the following error is produced:
```
ErrorException: Undefined variable: option - library/Sedo/AdvBBcodeBar/BbCode/Formatter/AdvBbCodes.php:438
```

useResponsiveMode is populated already, and article bbcode tag doesn't really support multiple options.